### PR TITLE
Add gitignore for node_modules and appmetrics-dash package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "node $npm_package_config_entrypoint"
   },
   "dependencies": {
+    "appmetrics-dash": "^5.2.0",
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "log4js": "^4.0.2"
@@ -24,5 +25,10 @@
     "nyc": "^14.1.1",
     "prompt-confirm": "^1.2.0",
     "request": "^2.82.0"
+  },
+  "nodemonConfig": {
+    "env": {
+      "NODE_HEAPDUMP_OPTIONS": "nosignal"
+    }
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,5 @@
+require('appmetrics-dash').attach();
+
 const appName = require('./../package').name;
 const http = require('http');
 const express = require('express');


### PR DESCRIPTION
### Summary
* Added `appmetrics-dash` package to display the dashboard.
* Added `nodemonConfig` to package.json.
* Added `.gitignore` so users won't commit their `node_modules` directory.

Fixes issue https://github.com/eclipse/codewind/issues/1142 in Codewind.

### Testing
* Ran locally using `npm install` and `npm start` loaded up `localhost:3000/appmetrics-dash` to verify the dashboard exists.

Signed-off-by: James Wallis <james.wallis1@ibm.com>