### PR TITLE
Update Helm chart for Kube 1.16+

### DIFF
--- a/chart/node/templates/deployment.yaml
+++ b/chart/node/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{  .Chart.Name }}-deployment"
@@ -12,6 +12,10 @@ spec:
       maxUnavailable: 0
       maxSurge: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: "{{  .Chart.Name }}-selector"
+      version: "current"
   template:
     metadata:
       labels:


### PR DESCRIPTION
This template's Helm chart needs to be updated for Kube 1.16 (and higher), which is the Kube version that OCP 4.3 will be using.

Tested with https://raw.githubusercontent.com/johnmcollier/codewind-templates-1/master/devfiles/index.json