### PR TITLE
Add back in scripts for debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   },
   "scripts": {
     "start": "node $npm_package_config_entrypoint"
+    "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint",	
+    "debug:brk": "node --inspect-brk=0.0.0.0:9229 $npm_package_config_entrypoint",	
+    "debug:legacy": "node --debug=0.0.0.0:5858 $npm_package_config_entrypoint",	
+    "test": "nyc mocha --exit",	
+    "dev": "nodemon $npm_package_config_entrypoint"
   },
   "dependencies": {
     "appmetrics-dash": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "start": "node $npm_package_config_entrypoint",
     "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint",	
     "debug:brk": "node --inspect-brk=0.0.0.0:9229 $npm_package_config_entrypoint",	
-    "debug:legacy": "node --debug=0.0.0.0:5858 $npm_package_config_entrypoint",	
-    "test": "nyc mocha --exit",	
-    "dev": "nodemon $npm_package_config_entrypoint"
+    "debug:legacy": "node --debug=0.0.0.0:5858 $npm_package_config_entrypoint"
   },
   "dependencies": {
     "appmetrics-dash": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "entrypoint": "server/server.js"
   },
   "scripts": {
-    "start": "node $npm_package_config_entrypoint"
+    "start": "node $npm_package_config_entrypoint",
     "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint",	
     "debug:brk": "node --inspect-brk=0.0.0.0:9229 $npm_package_config_entrypoint",	
     "debug:legacy": "node --debug=0.0.0.0:5858 $npm_package_config_entrypoint",	


### PR DESCRIPTION
a previous commit removed the scripts to enable debug.  This adds those scripts back in.

Fixes https://github.com/eclipse/codewind/issues/1709