### PR TITLE
Copy .npmrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Install npm production packages
-COPY package.json /app/
-RUN cd /app; npm install --production
+COPY package.json .npmrc* /app/
+RUN cd /app; npm install --production \
+ && rm -rf .npmrc*
 
 COPY . /app
 


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Resolves https://github.com/eclipse/codewind/issues/2488

Let the Dockerfile of the nodejs default template copy .npmrc into the docker build to allow installing packages from private registries.