### PR TITLE
Use multistage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY package.json .npmrc ./
 RUN npm install --production
 
 # Copy application source
-COPY . /
+COPY . ./
 RUN rm .npmrc
 
 


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

For https://github.com/eclipse/codewind/issues/2488

This PR fixes another problem spotted in #8, which is that it was leaving the `.npmrc` file in the image due to the `COPY . /app` command.  We could simply delete it after that command, but since the file was copied to a layer, it'll be there unless the final image is squashed.

This PR will fix that by making the docker build multi-staged so the `.npmrc` file never appear in the final image.