### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json


### PR DESCRIPTION
This repo should have a `.dockerignore` to exclude `node_modules` and `package-lock.json` from the image.  Noticed some weird behaviour when I had these in my local project.