### PR TITLE
feat: remove unhelpful link

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -12,7 +12,6 @@
             <div class="sad-cloud" ></div>
             <h1>404!</h1>
             <h2>Whoops! Looks like you got lost or couldn't find your page.</h2>
-            <h2>Click to go to the <a href="https://codewind.dev/" target="_blank">overview page</a>.</h2>
         </div>
     </div>
 </div>

--- a/public/500.html
+++ b/public/500.html
@@ -12,7 +12,6 @@
             <div class="sad-cloud"></div>
             <h1>Uh oh!</h1>
             <h2>Whoops! The server couldn't handle your request.</h2>
-            <h2>Click to go to the <a href="https://codewind.dev/" target="_blank">overview page</a>.</h2>
         </div>
     </div>
 </div>


### PR DESCRIPTION
_fixes https://github.com/eclipse/codewind/issues/3120 by removing this unhelpful link

![image](https://user-images.githubusercontent.com/18170169/84488889-c185cf80-ac98-11ea-9ad1-d35753526ffe.png)

and a similar one for the 500 error page. We have agreed that the link is not helpful